### PR TITLE
Add URI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ rrss is a drop-in replacement for Ring native stores:
 You can pass options such as:
 
     (def store
-      (redis-store {:host "localhost" :port 6379}))
+      (redis-store {:uri "redis://localhost:6379"}))
 
 This will create a default store, connecting a Redis server in the given host
 and port. Every sessions will be saved under a key of the form `sessions:ID`

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :comments "same as Clojure"}
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [ring/ring-core "0.3.5"]
-                 [redis.clients/jedis "1.5.0"]]
+                 [redis.clients/jedis "2.8.1"]]
   :dev-dependencies [[org.clojure/clojure-contrib "1.2.0"]
                      [autodoc "0.7.1" :exclusions [org.clojure/clojure
                                                    org.clojure/clojure-contrib]]]

--- a/src/rrss.clj
+++ b/src/rrss.clj
@@ -1,7 +1,6 @@
 (ns rrss
   "Ring Redis Session Store
   Ring session store implemented on top of Redis key/value store"
-  (:import org.apache.commons.pool.impl.GenericObjectPool$Config)
   (:import redis.clients.jedis.JedisPool)
   (:use [rrss.store :only (make-redis-store)])
   (:use [rrss.steps :only (create-step-chain)]
@@ -18,11 +17,6 @@
    :port 6379
    :key-mapper (add-prefix "sessions:")
    :steps []})
-
-(defn- pool-config
-  "Create a default pool"
-  [options]
-  (org.apache.commons.pool.impl.GenericObjectPool$Config.))
 
 (defn- all-steps
   "Join extra steps with the native steps needed for all stores"
@@ -41,7 +35,7 @@
   ([] (redis-store {}))
   ([options]
    (let [{:keys (host port)} (merge default-options options)]
-     (redis-store (JedisPool. (pool-config options) host port) options)))
+     (redis-store (JedisPool. host port) options)))
   ([pool options]
    (let [{:keys (key-mapper steps)} (merge default-options options)]
      (make-redis-store pool (create-step-chain (all-steps key-mapper steps))))))
@@ -64,7 +58,7 @@
   ([] (expiring-redis-store {}))
   ([options]
    (let [{:keys (host port)} (merge default-options options)
-         pool (JedisPool. (pool-config options) host port)]
+         pool (JedisPool. host port)]
      (expiring-redis-store pool options)))
   ([pool options]
    (let [{:keys (key-mapper steps)} (merge default-options options)

--- a/src/rrss/steps/expire_sessions_step.clj
+++ b/src/rrss/steps/expire_sessions_step.clj
@@ -19,7 +19,7 @@
         max-score (double (- now duration-ms))
         old-keys (.zrangeByScore connection all-sessions-key 0.0 max-score)]
     (doseq [key old-keys]
-      (.zrem connection all-sessions-key key)
+      (.zrem connection all-sessions-key (into-array String [key]))
       (.del connection (into-array String [key])))))
 
 

--- a/src/rrss/steps/sessions_set_step.clj
+++ b/src/rrss/steps/sessions_set_step.clj
@@ -22,6 +22,6 @@
         :delete (fn [opdata next-step]
                   (let [res (next-step opdata)]
                     (when-let [key (:redis-key res)]
-                      (.zrem (:connection res) set-key key))
+                      (.zrem (:connection res) set-key (into-array String [key])))
                     res))}))))
 

--- a/test/rrss_test.clj
+++ b/test/rrss_test.clj
@@ -18,7 +18,8 @@
 
 (deftest test-construction
   (is (redis-store))
-  (is (redis-store {:port 6378 :host "example.com"})))
+  (is (redis-store {:port 6378 :host "example.com"}))
+  (is (redis-store {:uri "redis://example.com:6378"})))
 
 (declare ^:dynamic store)
 

--- a/test/steps_test.clj
+++ b/test/steps_test.clj
@@ -66,9 +66,9 @@
   (let [store (redis-store {:steps [(sessions-set-step)]})]
     (write-session store "foo" {:hi :bye})
     (write-session store "bar" {:hi :bye})
-    (is (= #{"sessions:foo" "sessions:bar"} (.zrange jedis "sessions:all" 0 -1)))
+    (is (= #{"sessions:foo" "sessions:bar"} (into #{} (.zrange jedis "sessions:all" (long 0) (long -1)))))
     (delete-session store "bar")
-    (is (= #{"sessions:foo"} (.zrange jedis "sessions:all" 0 -1)))))
+    (is (= #{"sessions:foo"} (into #{} (.zrange jedis "sessions:all" (long 0) (long -1)))))))
 
 (defn millis-ago [time-str]
   (- (.getTime (Date.))
@@ -82,7 +82,7 @@
 (deftest set-and-time-steps
   (let [store (redis-store {:steps [(time-sessions-step) (sessions-set-step)]})]
     (write-session store "foo" {:hi :bye})
-    (is (= #{"sessions:foo"} (.zrange jedis "sessions:all" 0 -1)))
+    (is (= #{"sessions:foo"} (into #{} (.zrange jedis "sessions:all" (long 0) (long -1)))))
     (is (> 1000 (millis-ago (.get jedis "sessions:foo:written-at"))))))
 
 (deftest test-expire-sessions-step


### PR DESCRIPTION
On Heroku or in a Docker container configuration via a Redis URI is required. Later versions of Jedis support this. Thus this pull request also updates Jedis to the latest version.
